### PR TITLE
feat: contract

### DIFF
--- a/contracts/Masks/DEFYMasks.sol
+++ b/contracts/Masks/DEFYMasks.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "operator-filter-registry/src/DefaultOperatorFilterer.sol";
+
+contract DEFYMasks is
+    ERC721,
+    ERC721Enumerable,
+    Pausable,
+    Ownable,
+    AccessControl,
+    DefaultOperatorFilterer
+{
+    using Counters for Counters.Counter;
+
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+
+    // Permits an address to transfer below 1 mask
+    mapping(address => bool) private _tokenTradingEnabled;
+
+    Counters.Counter private _tokenIdCounter;
+
+    // Base URI for mask token uris
+    string private _maskBaseURI;
+
+    /// @notice Sets the base URI used for the tokens.
+    function setBaseURI(string memory uri) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _maskBaseURI = uri;
+    }
+
+    /// @notice Get the TokenURI for the supplied token, in the form {baseURI}{tokenId}
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        require(_exists(tokenId), "DEFYMasks: URI query for nonexistent token");
+
+        return
+            string(
+                abi.encodePacked(
+                    _maskBaseURI,
+                    Strings.toString(tokenId),
+                    ".json"
+                )
+            );
+    }
+
+    constructor() ERC721("DEFYMasks", "DM") {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(PAUSER_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
+        _grantRole(BURNER_ROLE, msg.sender);
+    }
+
+    function safeMint(address to) public onlyRole(MINTER_ROLE) {
+        uint256 tokenId = _tokenIdCounter.current();
+        _tokenIdCounter.increment();
+        _safeMint(to, tokenId);
+    }
+
+    function safeBatchMint(address[] calldata to) public onlyRole(MINTER_ROLE) {
+        for (uint256 i = 0; i < to.length; i++) {
+            safeMint(to[i]);
+        }
+    }
+
+    function burnMask(uint256 tokenId) public onlyRole(BURNER_ROLE) {
+        _burn(tokenId);
+    }
+
+    function batchBurnMasks(uint256[] calldata tokenIds)
+        public
+        onlyRole(BURNER_ROLE)
+    {
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            _burn(tokenIds[i]);
+        }
+    }
+
+    // Checks for token transfers and burns that either:
+    //  Admin enabled trading for operative address; or,
+    //  Operative Address will have at least 1 mask after transfer
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override(ERC721, ERC721Enumerable) whenNotPaused {
+        require(
+            _tokenTradingEnabled[from] || balanceOf(from) >= 2,
+            "DEFYMasks: Token trading is not enabled"
+        );
+
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    function setTokenTradingEnabledForToken(
+        address operativeAddress,
+        bool enabled
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _tokenTradingEnabled[operativeAddress] = enabled;
+    }
+
+    // Utility Functions
+
+    function pause() public onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    // Operator Filter Registry
+
+    function setApprovalForAll(address operator, bool approved)
+        public
+        override(ERC721, IERC721)
+        onlyAllowedOperatorApproval(operator)
+    {
+        super.setApprovalForAll(operator, approved);
+    }
+
+    function approve(address operator, uint256 tokenId)
+        public
+        override(ERC721, IERC721)
+        onlyAllowedOperatorApproval(operator)
+    {
+        super.approve(operator, tokenId);
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    // The following functions are overrides required by Solidity.
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721, ERC721Enumerable, AccessControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/Masks/DEFYMasks.sol
+++ b/contracts/Masks/DEFYMasks.sol
@@ -9,6 +9,15 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "operator-filter-registry/src/DefaultOperatorFilterer.sol";
 
+// ______ _____________   __
+// |  _  \  ___|  ___\ \ / /
+// | | | | |__ | |_   \ V /
+// | | | |  __||  _|   \ /
+// | |/ /| |___| |     | |
+// |___/ \____/\_|     \_/
+//
+// WELCOME TO THE REVOLUTION
+
 contract DEFYMasks is
     ERC721,
     ERC721Enumerable,

--- a/contracts/Masks/DEFYMasks.sol
+++ b/contracts/Masks/DEFYMasks.sol
@@ -76,6 +76,8 @@ contract DEFYMasks is
     }
 
     function safeBatchMint(address[] calldata to) public onlyRole(MINTER_ROLE) {
+        require(to.length <= 80, "DEFYMasks: mint batch max count is 80");
+
         for (uint256 i = 0; i < to.length; i++) {
             safeMint(to[i]);
         }
@@ -89,6 +91,7 @@ contract DEFYMasks is
         public
         onlyRole(BURNER_ROLE)
     {
+        require(tokenIds.length <= 80, "DEFYMasks: mint batch max count is 80");
         for (uint256 i = 0; i < tokenIds.length; i++) {
             _burn(tokenIds[i]);
         }

--- a/contracts/Masks/DEFYMasks.sol
+++ b/contracts/Masks/DEFYMasks.sol
@@ -67,8 +67,6 @@ contract DEFYMasks is
     constructor() ERC721("DEFYMasks", "DM") {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
-        _grantRole(MINTER_ROLE, msg.sender);
-        _grantRole(BURNER_ROLE, msg.sender);
     }
 
     function safeMint(address to) public onlyRole(MINTER_ROLE) {
@@ -99,15 +97,18 @@ contract DEFYMasks is
     // Checks for token transfers and burns that either:
     //  Admin enabled trading for operative address; or,
     //  Operative Address will have at least 1 mask after transfer
+    // If check to allow minting to bypass check
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256 tokenId
     ) internal override(ERC721, ERC721Enumerable) whenNotPaused {
-        require(
-            _tokenTradingEnabled[from] || balanceOf(from) >= 2,
-            "DEFYMasks: Token trading is not enabled"
-        );
+        if (tokenId < totalSupply()) {
+            require(
+                _tokenTradingEnabled[from] || balanceOf(from) >= 2,
+                "DEFYMasks: Token trading is not enabled"
+            );
+        }
 
         super._beforeTokenTransfer(from, to, tokenId);
     }

--- a/test/DEFYMasks-test.js
+++ b/test/DEFYMasks-test.js
@@ -117,5 +117,19 @@ describe("DEFYMasks", function () {
             expect(await defyMasks.ownerOf(0)).to.be.equal(SECONDARY_ADDRESS);
         });
 
+        it("Should fail transfers with 1 mask after an owner has transferred already", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.setTokenTradingEnabledForToken(DEFAULT_ADDRESS, true);
+            await defyMasks.transferFrom(DEFAULT_ADDRESS, SECONDARY_ADDRESS, 0);
+            expect(await defyMasks.balanceOf(SECONDARY_ADDRESS)).to.equal(1);
+            expect(await defyMasks.ownerOf(0)).to.be.equal(SECONDARY_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            expect(await defyMasks.ownerOf(1)).to.be.equal(DEFAULT_ADDRESS);
+            await expect(defyMasks.transferFrom(DEFAULT_ADDRESS, SECONDARY_ADDRESS, 1)).to.revertedWith(
+                "DEFYMasks: Token trading is not enabled");
+        });
+
     });
 });

--- a/test/DEFYMasks-test.js
+++ b/test/DEFYMasks-test.js
@@ -1,0 +1,121 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+let DEFYMasks;
+let defyMasks;
+
+let DEFAULT_ADMIN_ROLE, MINTER_ROLE, BURNER_ROLE, PAUSER_ROLE;
+
+let DEFAULT_OWNER, addr1;
+
+describe("DEFYMasks", function () {
+
+    beforeEach(async function () {
+        DEFYMasks = await ethers.getContractFactory("DEFYMasks");
+        defyMasks = await DEFYMasks.deploy();
+        await defyMasks.deployed();
+
+        DEFAULT_ADMIN_ROLE = await defyMasks['DEFAULT_ADMIN_ROLE()']();
+        PAUSER_ROLE = await defyMasks['PAUSER_ROLE()']();
+        MINTER_ROLE = await defyMasks['MINTER_ROLE()']();
+        BURNER_ROLE = await defyMasks['BURNER_ROLE()']();
+
+        const [owner, secondaryAddress] = await ethers.getSigners();
+
+        DEFAULT_ADDRESS = owner.address;
+        SECONDARY_ADDRESS = secondaryAddress.address;
+
+        DEFAULT_OWNER = owner;
+        addr1 = secondaryAddress;
+
+    });
+
+    describe('DEFYMasks', () => {
+        it("Should fail to mint for a non-minter", async function () {
+            await expect(defyMasks.safeMint(DEFAULT_ADDRESS)).to.be.revertedWith(
+                'AccessControl: account ');
+        });
+
+        it("Should fail to burn for a non-burner", async function () {
+            await expect(defyMasks.burnMask(DEFAULT_ADDRESS)).to.be.revertedWith(
+                'AccessControl: account ');
+        });
+
+        it("Should allow minter to perform mints", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            expect(await defyMasks.balanceOf(DEFAULT_ADDRESS)).to.equal(1);
+            expect(await defyMasks.ownerOf(0)).to.equal(DEFAULT_ADDRESS);
+
+        });
+
+        it("Should allow burner to perform burns", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeBatchMint([DEFAULT_ADDRESS, DEFAULT_ADDRESS]);
+            expect(await defyMasks.balanceOf(DEFAULT_ADDRESS)).to.equal(2);
+            await defyMasks.burnMask(0);
+            expect(await defyMasks.balanceOf(DEFAULT_ADDRESS)).to.equal(1);
+            await expect(defyMasks.ownerOf(0)).to.revertedWith(
+                'ERC721: owner query for nonexistent token');
+        });
+
+        it("Should allow minter to perform batch mints", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeBatchMint([DEFAULT_ADDRESS, DEFAULT_ADDRESS, SECONDARY_ADDRESS]);
+            expect(await defyMasks.balanceOf(DEFAULT_ADDRESS)).to.equal(2);
+            expect(await defyMasks.balanceOf(SECONDARY_ADDRESS)).to.equal(1);
+        });
+
+        it("Should prevent burning when owner has 1 mask", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await expect(defyMasks.burnMask(0)).to.be.revertedWith(
+                "DEFYMasks: Token trading is not enabled"
+            );
+        });
+
+        it("Should prevent transfers when owner has 1 mask", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await expect(defyMasks.transferFrom(DEFAULT_ADDRESS, SECONDARY_ADDRESS, 0)).to.be.revertedWith(
+                "DEFYMasks: Token trading is not enabled"
+            );
+        });
+
+        it("Should allow transfers when owner has 2 masks", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.transferFrom(DEFAULT_ADDRESS, SECONDARY_ADDRESS, 0);
+            expect(await defyMasks.balanceOf(SECONDARY_ADDRESS)).to.equal(1);
+            expect(await defyMasks.ownerOf(0)).to.be.equal(SECONDARY_ADDRESS);
+        });
+
+        it("Should allow burns when owner has 2 masks", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.burnMask(1);
+            expect(await defyMasks.balanceOf(DEFAULT_ADDRESS)).to.equal(1);
+            await expect(defyMasks.ownerOf(1)).to.revertedWith(
+                'ERC721: owner query for nonexistent token');
+        });
+
+        it("Should allow transfers with 1 mask when owner transfer is admin enabled", async function () {
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](BURNER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks.safeMint(DEFAULT_ADDRESS);
+            await defyMasks.setTokenTradingEnabledForToken(DEFAULT_ADDRESS, true);
+            await defyMasks.transferFrom(DEFAULT_ADDRESS, SECONDARY_ADDRESS, 0);
+            expect(await defyMasks.balanceOf(SECONDARY_ADDRESS)).to.equal(1);
+            expect(await defyMasks.ownerOf(0)).to.be.equal(SECONDARY_ADDRESS);
+        });
+
+    });
+});


### PR DESCRIPTION
here's the basic Mask Contract

just a thought, the admin account can essentially burn any token/mask they choose.

would it be better to extend from ERC721Burnable? however, this poses other issues, as an operative needs to give permission to burn etc.

This way works fine and is what is happening with the loot contract