### PR TITLE
Feature/defy matic faucet

### DIFF
--- a/contracts/Faucet/DEFYMaticFaucet.sol
+++ b/contracts/Faucet/DEFYMaticFaucet.sol
@@ -56,7 +56,7 @@ contract DEFYMaticFaucet is Pausable, AccessControl {
 
     function withdrawAllMatic(
         address payable to
-    ) external payable onlyRole(DEFAULT_ADMIN_ROLE) {
+    ) external payable whenNotPaused onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 amount = getBalance();
         (bool success, ) = to.call{value: amount}("");
         require(success, "transaction failed");

--- a/contracts/Faucet/DEFYMaticFaucet.sol
+++ b/contracts/Faucet/DEFYMaticFaucet.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "../Items/IDEFYLoot.sol";
+import "../Masks/IDEFYMasks.sol";
+
+// ______ _____________   __
+// |  _  \  ___|  ___\ \ / /
+// | | | | |__ | |_   \ V /
+// | | | |  __||  _|   \ /
+// | |/ /| |___| |     | |
+// |___/ \____/\_|     \_/
+//
+// WELCOME TO THE REVOLUTION
+
+/// @custom:security-contact michael@defylabs.xyz
+contract DEFYMaticFaucet is Pausable, AccessControl {
+    bytes32 public constant FAUCET_ROLE = keccak256("FAUCET_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // Faucet amount in wei
+    uint256 public faucetAmount;
+    IDEFYLoot public defyLoot;
+    IDEFYMasks public defyMasks;
+    uint256 public lootItem;
+
+    mapping(address => bool) private _maticFaucetClaimed;
+
+    constructor(
+        IDEFYLoot lootContract,
+        IDEFYMasks masksContract,
+        uint256 lootItemToCheck
+    ) {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+
+        defyLoot = lootContract;
+        defyMasks = masksContract;
+        lootItem = lootItemToCheck;
+    }
+
+    // Utility functions
+    function pause() public onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    function getBalance() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function withdrawAllMatic(
+        address payable to
+    ) external payable onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256 amount = getBalance();
+        (bool success, ) = to.call{value: amount}("");
+        require(success, "transaction failed");
+    }
+
+    function requestMatic(
+        address payable to
+    ) public payable whenNotPaused onlyRole(FAUCET_ROLE) {
+        // check address is not contract address
+        require(
+            !Address.isContract(to),
+            "DEFYMaticFaucet: Address is a contract address"
+        );
+
+        // address has 0 matic
+        require(to.balance == 0, "DEFYMaticFaucet: Address already has Matic");
+
+        // address has defyLoot
+        require(
+            defyLoot.balanceOf(to, lootItem) >= 1,
+            "DEFYMaticFaucet: Address does not own specified item"
+        );
+
+        // address has a free mask
+        require(
+            defyMasks.balanceOf(to) >= 1,
+            "DEFYMaticFaucet: Address does not own a mask"
+        );
+
+        // address has not claimed before
+        require(
+            !_maticFaucetClaimed[to],
+            "DEFYMaticFaucet: Address has already claimed Matic"
+        );
+
+        // set claimed flag
+        _maticFaucetClaimed[to] = true;
+
+        // send matic to operative address
+        (bool success, ) = to.call{value: faucetAmount}("");
+        require(success, "transaction failed");
+    }
+
+    // set faucent amount in Wei
+    function setFaucetAmount(
+        uint256 amount
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        faucetAmount = amount;
+    }
+
+    function setDEFYLootContract(
+        IDEFYLoot defyLootContract
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        defyLoot = defyLootContract;
+    }
+
+    function setDEFYMasksContract(
+        IDEFYMasks defyMasksContract
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        defyMasks = defyMasksContract;
+    }
+
+    function setLootItem(
+        uint256 lootItemTokenId
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        lootItem = lootItemTokenId;
+    }
+
+    // receives matic
+    receive() external payable {}
+
+    fallback() external payable {}
+}

--- a/scripts/faucet/deploy-matic-faucet.js
+++ b/scripts/faucet/deploy-matic-faucet.js
@@ -1,0 +1,33 @@
+// We require the Hardhat Runtime Environment explicitly here. This is optional
+// but useful for running the script in a standalone fashion through `node <script>`.
+//
+// When running the script with `npx hardhat run <script>` you'll find the Hardhat
+// Runtime Environment's members available in the global scope.
+const hre = require("hardhat");
+const { ethers } = hre;
+
+async function main() {
+    const DEFYMaticFaucet = await ethers.getContractFactory("DEFYMaticFaucet");
+    const defyMaticFaucet = await DEFYMaticFaucet.deploy();
+
+    await defyMaticFaucet.deployed();
+
+    console.log("defyMaticFaucet deployed to:", defyMaticFaucet.address);
+
+    console.log("waiting 30s then verifying...");
+    await new Promise(r => setTimeout(r, 30000));
+
+    console.log("verifying");
+    await hre.run("verify:verify", {
+        address: defyMaticFaucet.address,
+    });
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/test/DEFYMaticFaucet-test.js
+++ b/test/DEFYMaticFaucet-test.js
@@ -1,0 +1,163 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+const { BigNumber } = require("ethers");
+
+let DEFYMaticFaucet;
+let defyMaticFaucet;
+
+let DEFYLoot;
+let defyLoot;
+
+let DEFYMasks;
+let defyMasks;
+
+let DEFAULT_ADMIN_ROLE, MINTER_ROLE, PAUSER_ROLE, FAUCET_ROLE;
+
+let addressWithNoEther, connectedAddressWithNoEther;
+
+describe("DEFYMaticFaucet", function () {
+
+    beforeEach(async function () {
+        DEFYLoot = await ethers.getContractFactory("DEFYLoot");
+        defyLoot = await DEFYLoot.deploy();
+        await defyLoot.deployed();
+
+        DEFYMasks = await ethers.getContractFactory("DEFYMasks");
+        defyMasks = await DEFYMasks.deploy();
+        await defyMasks.deployed();
+
+        DEFYMaticFaucet = await ethers.getContractFactory("DEFYMaticFaucet");
+        defyMaticFaucet = await DEFYMaticFaucet.deploy(defyLoot.address, defyMasks.address, 3);
+        await defyMaticFaucet.deployed();
+
+        DEFAULT_ADMIN_ROLE = await defyLoot['DEFAULT_ADMIN_ROLE()']();
+        PAUSER_ROLE = await defyLoot['PAUSER_ROLE()']();
+        MINTER_ROLE = await defyLoot['MINTER_ROLE()']();
+        URI_SETTER_ROLE = await defyLoot['URI_SETTER_ROLE()']();
+
+        DEFAULT_ADMIN_ROLE = await defyMaticFaucet['DEFAULT_ADMIN_ROLE()']();
+        FAUCET_ROLE = await defyMaticFaucet['FAUCET_ROLE()']();
+
+        DEFAULT_ADMIN_ROLE = await defyMasks['DEFAULT_ADMIN_ROLE()']();
+        PAUSER_ROLE = await defyMasks['PAUSER_ROLE()']();
+        MINTER_ROLE = await defyMasks['MINTER_ROLE()']();
+
+        const [owner, secondaryAddress] = await ethers.getSigners();
+
+        DEFAULT_ADDRESS = owner.address;
+        SECONDARY_ADDRESS = secondaryAddress.address;
+
+        DEFAULT_OWNER = owner;
+        addr1 = secondaryAddress;
+
+        const randomWallet = ethers.Wallet.createRandom();
+        addressWithNoEther = randomWallet.address;
+        connectedAddressWithNoEther = randomWallet.connect(ethers.provider);
+    });
+
+    describe('DEFYMaticFaucet', () => {
+        it('Should receive Matic', async function () {
+            await DEFAULT_OWNER.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            expect(await defyMaticFaucet.getBalance()).to.equal(ethers.utils.parseEther("1"));
+        });
+
+        it('Should withdraw all matic to owner', async function () {
+            await DEFAULT_OWNER.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            var beforeAmount = await DEFAULT_OWNER.getBalance();
+
+            await defyMaticFaucet.withdrawAllMatic(DEFAULT_ADDRESS);
+            expect(await defyMaticFaucet.getBalance()).to.equal(0);
+
+            var afterAmount = await DEFAULT_OWNER.getBalance();
+            expect((afterAmount - beforeAmount) / 1e18).to.be.below(1).and.above(0.999)
+
+        });
+
+        if ('Should fail to faucet if the caller is not FAUCET_ROLE', async function () {
+            await DEFAULT_OWNER.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            await expect(defyMaticFaucet.requestMatic(SECONDARY_ADDRESS))
+                .to.be.revertedWith('AccessControl: ');
+        });
+
+        it('Should fail to faucet if address has matic', async function () {
+            await defyMaticFaucet['grantRole(bytes32,address)'](FAUCET_ROLE, DEFAULT_ADDRESS);
+            await DEFAULT_OWNER.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            await expect(defyMaticFaucet.requestMatic(SECONDARY_ADDRESS))
+                .to.be.revertedWith('DEFYMaticFaucet: Address already has Matic');
+        });
+
+        it('Should fail to faucet if address has no loot', async function () {
+            await defyMaticFaucet['grantRole(bytes32,address)'](FAUCET_ROLE, DEFAULT_ADDRESS);
+            await addr1.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+
+            await expect(defyMaticFaucet.requestMatic(addressWithNoEther))
+                .to.be.revertedWith('DEFYMaticFaucet: Address does not own specified item');
+        });
+
+        it('Should fail to faucet if address has no mask', async function () {
+            await defyMaticFaucet['grantRole(bytes32,address)'](FAUCET_ROLE, DEFAULT_ADDRESS);
+            await defyLoot['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await addr1.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            await defyLoot.mint(addressWithNoEther, 3, 3, 0x00);
+
+            await expect(defyMaticFaucet.requestMatic(addressWithNoEther))
+                .to.be.revertedWith('DEFYMaticFaucet: Address does not own a mask');
+        });
+
+        it('Should fail to faucet if address has already claimed', async function () {
+            await defyMaticFaucet['grantRole(bytes32,address)'](FAUCET_ROLE, DEFAULT_ADDRESS);
+            await defyLoot['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+
+            await addr1.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            await defyLoot.mint(addressWithNoEther, 3, 3, 0x00);
+            await defyMasks.safeMint(addressWithNoEther);
+
+            await defyMaticFaucet.setFaucetAmount(0);
+            await defyMaticFaucet.requestMatic(addressWithNoEther);
+
+            await expect(defyMaticFaucet.requestMatic(addressWithNoEther))
+                .to.be.revertedWith('DEFYMaticFaucet: Address has already claimed Matic');
+        });
+
+        it('Should faucet the correct matic to address', async function () {
+            await defyMaticFaucet['grantRole(bytes32,address)'](FAUCET_ROLE, DEFAULT_ADDRESS);
+            await defyLoot['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+            await defyMasks['grantRole(bytes32,address)'](MINTER_ROLE, DEFAULT_ADDRESS);
+
+            await addr1.sendTransaction({
+                to: defyMaticFaucet.address,
+                value: ethers.utils.parseEther("1")
+            });
+            await defyLoot.mint(addressWithNoEther, 3, 3, 0x00);
+            await defyMasks.safeMint(addressWithNoEther);
+
+            await defyMaticFaucet.setFaucetAmount(1e9);
+            await defyMaticFaucet.requestMatic(addressWithNoEther);
+            expect(await connectedAddressWithNoEther.getBalance()).to.equal(ethers.BigNumber.from(1e9));
+        });
+
+    });
+});


### PR DESCRIPTION
Contract that faucets to users with no Matic.

Cannot check for any 1155 token, as you need to specify which token you want the balance of.
i.e. `balanceOf(address account, uint256 id)`. So I have set it to check for a specific token. Couple options here:
1. just check for a token everyone should have like Retrieval Drone (3)
2. check for a couple of things everyone should have like Retrieval Drone (3), Scrap (10,000) etc.

The faucetAmount appears to be set in Wei, but would definitely want to double check this on testnet.